### PR TITLE
Fix Google Finance URL

### DIFF
--- a/googlefinance/client.py
+++ b/googlefinance/client.py
@@ -3,8 +3,12 @@ import requests
 from datetime import datetime
 import pandas as pd
 
+
+GOOGLE_FINANCE_URL = "https://finance.google.com/finance/getprices"
+
+
 def get_price_data(query):
-	r = requests.get("https://www.google.com/finance/getprices", params=query)
+	r = requests.get(GOOGLE_FINANCE_URL, params=query)
 	lines = r.text.splitlines()
 	data = []
 	index = []
@@ -26,7 +30,7 @@ def get_closing_data(queries, period):
 	for query in queries:
 		query['i'] = 86400
 		query['p'] = period
-		r = requests.get("https://www.google.com/finance/getprices", params=query)
+		r = requests.get(GOOGLE_FINANCE_URL, params=query)
 		lines = r.text.splitlines()
 		data = []
 		index = []
@@ -51,7 +55,7 @@ def get_open_close_data(queries, period):
 	for query in queries:
 		query['i'] = 86400
 		query['p'] = period
-		r = requests.get("https://www.google.com/finance/getprices", params=query)
+		r = requests.get(GOOGLE_FINANCE_URL, params=query)
 		lines = r.text.splitlines()
 		data = []
 		index = []
@@ -76,7 +80,7 @@ def get_prices_data(queries, period):
 	for query in queries:
 		query['i'] = 86400
 		query['p'] = period
-		r = requests.get("https://www.google.com/finance/getprices", params=query)
+		r = requests.get(GOOGLE_FINANCE_URL, params=query)
 		lines = r.text.splitlines()
 		data = []
 		index = []
@@ -101,7 +105,7 @@ def get_prices_time_data(queries, period, interval):
 	for query in queries:
 		query['i'] = interval
 		query['p'] = period
-		r = requests.get("https://www.google.com/finance/getprices", params=query)
+		r = requests.get(GOOGLE_FINANCE_URL, params=query)
 		lines = r.text.splitlines()
 		data = []
 		index = []


### PR DESCRIPTION
Fixes #3 

The URL `https://www.google.com/finance/getprices` is being redirected to `https://www.google.com.br/search?` (HTML response) and not properly redirecting to `https://finance.google.com.br/search` (TXT response) as expected.

How to reproduce the error:
```
from googlefinance.client import get_price_data
param = {
    'q': "IBOV",
    'i': "86400",
    'x': "INDEXBVMF",
    'p': "5Y",
}
get_price_data(param)
```
Which access [google.com](https://www.google.com.br/search?q=IBOV&gws_rd=cr&dcr=0&ei=j1QfWv6MFsnCwATakJ_wAg), but the expected response is in  [finance.google](https://finance.google.com/finance/getprices?q=IBOV&i=86400&x=INDEXBVMF&p=5Y).

This PR changes the URL to use `https://finance.google.com.br/search`.