### PR TITLE
fixed time zone bug

### DIFF
--- a/googlefinance/client.py
+++ b/googlefinance/client.py
@@ -2,9 +2,11 @@
 import requests
 from datetime import datetime
 import pandas as pd
+import pytz
 
 def get_price_data(query):
 	r = requests.get("https://finance.google.com/finance/getprices", params=query)
+	# print(r.url)
 	lines = r.text.splitlines()
 	data = []
 	index = []
@@ -13,11 +15,15 @@ def get_price_data(query):
 		cols = price.split(",")
 		if cols[0][0] == 'a':
 			basetime = int(cols[0][1:])
-			index.append(datetime.fromtimestamp(basetime))
+			# index.append(datetime.fromtimestamp(basetime))
+			index.append(datetime.fromtimestamp(basetime, pytz.timezone(
+				'America/New_York')))
 			data.append([float(cols[4]), float(cols[2]), float(cols[3]), float(cols[1]), int(cols[5])])
 		elif cols[0][0].isdigit():
 			date = basetime + (int(cols[0])*int(query['i']))
-			index.append(datetime.fromtimestamp(date))
+			# index.append(datetime.fromtimestamp(date))
+			index.append(datetime.fromtimestamp(date, pytz.timezone(
+				'America/New_York')))
 			data.append([float(cols[4]), float(cols[2]), float(cols[3]), float(cols[1]), int(cols[5])])
 	return pd.DataFrame(data, index = index, columns = ['Open', 'High', 'Low', 'Close', 'Volume'])
 
@@ -37,11 +43,15 @@ def get_closing_data(queries, period):
 				basetime = int(cols[0][1:])
 				date = basetime
 				data.append(float(cols[1]))
-				index.append(datetime.fromtimestamp(date).date())
+				# index.append(datetime.fromtimestamp(date).date())
+				index.append(datetime.fromtimestamp(basetime, pytz.timezone(
+					'America/New_York')))
 			elif cols[0][0].isdigit():
 				date = basetime + (int(cols[0])*int(query['i']))
 				data.append(float(cols[1]))
-				index.append(datetime.fromtimestamp(date).date())
+				# index.append(datetime.fromtimestamp(date).date())
+				index.append(datetime.fromtimestamp(date, pytz.timezone(
+					'America/New_York')))
 		s = pd.Series(data,index=index,name=query['q'])
 		closing_data.append(s[~s.index.duplicated(keep='last')])
 	return pd.concat(closing_data, axis=1)
@@ -62,11 +72,15 @@ def get_open_close_data(queries, period):
 				basetime = int(cols[0][1:])
 				date = basetime
 				data.append([float(cols[4]), float(cols[1])])
-				index.append(datetime.fromtimestamp(date).date())
+				# index.append(datetime.fromtimestamp(date).date())
+				index.append(datetime.fromtimestamp(basetime, pytz.timezone(
+					'America/New_York')))
 			elif cols[0][0].isdigit():
 				date = basetime + (int(cols[0])*int(query['i']))
 				data.append([float(cols[4]), float(cols[1])])
-				index.append(datetime.fromtimestamp(date).date())
+				# index.append(datetime.fromtimestamp(date).date())
+				index.append(datetime.fromtimestamp(date, pytz.timezone(
+					'America/New_York')))
 		df = pd.DataFrame(data, index=index, columns=[query['q']+'_Open',query['q']+'_Close'])
 		open_close_data = pd.concat([open_close_data, df[~df.index.duplicated(keep='last')]], axis=1)
 	return open_close_data
@@ -87,11 +101,15 @@ def get_prices_data(queries, period):
 				basetime = int(cols[0][1:])
 				date = basetime
 				data.append([float(cols[4]), float(cols[2]), float(cols[3]), float(cols[1]), int(cols[5])])
-				index.append(datetime.fromtimestamp(date).date())
+				# index.append(datetime.fromtimestamp(date).date())
+				index.append(datetime.fromtimestamp(basetime, pytz.timezone(
+					'America/New_York')))
 			elif cols[0][0].isdigit():
 				date = basetime + (int(cols[0])*int(query['i']))
 				data.append([float(cols[4]), float(cols[2]), float(cols[3]), float(cols[1]), int(cols[5])])
-				index.append(datetime.fromtimestamp(date).date())
+				# index.append(datetime.fromtimestamp(date).date())
+				index.append(datetime.fromtimestamp(date, pytz.timezone(
+					'America/New_York')))
 		df = pd.DataFrame(data, index=index, columns=[query['q']+'_Open',query['q']+'_High',query['q']+'_Low',query['q']+'_Close',query['q']+'_Volume'])
 		prices_data = pd.concat([prices_data, df[~df.index.duplicated(keep='last')]], axis=1)
 	return prices_data
@@ -112,11 +130,15 @@ def get_prices_time_data(queries, period, interval):
 				basetime = int(cols[0][1:])
 				date = basetime
 				data.append([float(cols[4]), float(cols[2]), float(cols[3]), float(cols[1]), int(cols[5])])
-				index.append(datetime.fromtimestamp(date))
+				# index.append(datetime.fromtimestamp(date))
+				index.append(datetime.fromtimestamp(basetime, pytz.timezone(
+					'America/New_York')))
 			elif cols[0][0].isdigit():
 				date = basetime + (int(cols[0])*int(query['i']))
 				data.append([float(cols[4]), float(cols[2]), float(cols[3]), float(cols[1]), int(cols[5])])
-				index.append(datetime.fromtimestamp(date))
+				# index.append(datetime.fromtimestamp(date))
+				index.append(datetime.fromtimestamp(date, pytz.timezone(
+					'America/New_York')))
 		df = pd.DataFrame(data, index=index, columns=[query['q']+'_Open',query['q']+'_High',query['q']+'_Low',query['q']+'_Close',query['q']+'_Volume'])
 		prices_time_data = pd.concat([prices_time_data, df[~df.index.duplicated(keep='last')]], axis=1)
 	return prices_time_data


### PR DESCRIPTION
The current version of client is using the default timezone to encode a time string from the timestamp returned. It causes the encoded time string as a local one since the default timezone in python is localized. For example, if I'm in UTC+8, the encoded time string will be about 12/13 hours earlier than the real one. So I add a timezone parameter for the datetime.fromtimestamp function.